### PR TITLE
Extend panel chairs

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ There are many topics, problems, or ideas best tackled by a group of people with
 
 ### Solid Panels
 
-Solid Panels are groups of individuals focused on a specific problem or domain relevant to Solid, with an aim to propose changes to the [Solid Specification](https://github.com/solid/specification). Domains may be technical, non-technical, or some combination of the two. For example, a Security Panel could focus on the evaluation and advancement of the Solid security model. Anyone may join a panel.
+Solid Panels are groups of individuals focused on a specific problem or domain relevant to Solid, with an aim to propose changes to the [Solid Specification](https://github.com/solid/specification). Domains may be technical, non-technical, or some combination of the two. For example, a Security Panel could focus on the evaluation and advancement of the Solid security model. Only members of the [W3C Solid Community Group](https://www.w3.org/community/solid/), which anyone may join, and which operates under the [W3C Community Contributor License Agreement](https://www.w3.org/community/about/agreements/cla/), may become a member of a Solid Panel.
 
 New panels may be proposed by submitting an issue to the [solid/process](https://github.com/solid/process) repository. Establishing a new panel requires the endorsement of at least one member of the [Editorial Team](https://github.com/orgs/solid/teams/editors). To receive endorsement, the proposed panel submission must include:
 

--- a/README.md
+++ b/README.md
@@ -27,9 +27,9 @@ New panels may be proposed by submitting an issue to the [solid/process](https:/
 
 Any iteration on the stated purpose, initiatives, and supporting members should continue as needed until endorsement is received from at least one member of the Editorial Team. Submissions that fail to receive endorsement may be removed by Solid Administrators after six months.
 
-Any Editor endorsing a panel is expected to attend regular sessions, and to provide the Panel Chair and Panel with insight on specification priorities, as well as support work on any relevant initiatives in flight.
+Any Editor endorsing a panel is expected to attend regular sessions, and to provide the Panel Chairs and Panel with insight on specification priorities, as well as support work on any relevant initiatives in flight.
 
-Each panel is chaired by a Panel Chair. An Editorial Team member endorsing a panel is responsible for electing the Panel Chair, barring any vetoes from another Editor, or vetoes from a majority of panel members. The Solid Director reserves the right to elect and/or change the Panel Chair. In the event that an Editor should be nominated as a Panel Chair, they must be elected by another member of the Editorial Team.
+Each panel is chaired by one or more Panel Chairs. An Editorial Team member endorsing a panel is responsible for electing the Panel Chairs, barring any vetoes from another Editor, another Panel Chair of the same panel, or vetoes from a majority of panel members. The Solid Director reserves the right to elect and/or change Panel Chairs. In the event that an Editor should be nominated as a Panel Chair, they must be elected by another member of the Editorial Team.
 
  Responsibilities of a Panel Chair include but are not limited to:
 


### PR DESCRIPTION
Allows panels to have more than one chair and requires w3c community group membership for panel members.